### PR TITLE
ヘッダーのフロント表示パーツ化

### DIFF
--- a/wp-content/themes/urushitoki/includes/header.php
+++ b/wp-content/themes/urushitoki/includes/header.php
@@ -1,0 +1,15 @@
+<?php if (!(is_front_page(  ))):
+	$titleEn = get_post_meta( get_the_ID(), 'title_english', true );
+	$titleDesc = get_post_meta( get_the_ID(), 'title_description', true );
+	$img = get_eyecatch_default();
+?>
+<!-- フロントページ以外のヘッダーのパーツ -->
+<!-- マークアップは仮です。 -->
+<header class="masthead" style="background-image: url('<?php echo $img[0];?>')">
+	<h1 class="c-title--header" title-english="<?php echo esc_attr($titleEn)?>"> <?php the_title( );?></h1>
+	<p><?php echo $titleDesc?></p>
+</header>
+<!-- フロントページのヘッダーのパーツ -->
+<?php else:?>
+	<h1>こちらはフロントページのヘッダー</h1>
+<?php endif;?>

--- a/wp-content/themes/urushitoki/index.php
+++ b/wp-content/themes/urushitoki/index.php
@@ -1,8 +1,7 @@
 <?php get_header(); ?>
 <body>
-	<header>
-		<h1 class="test-header">テスト</h1>
-	</header>
+	<!-- ヘッダーのフロントに表示 -->
+	<?php get_template_part('/includes/header')?>
 	<article class="documentClass">
     	<h1>Css Test</h1>
 	</article>
@@ -112,3 +111,4 @@
 
 
 	<?php get_footer(); ?>
+

--- a/wp-content/themes/urushitoki/production/php/includes/header.php
+++ b/wp-content/themes/urushitoki/production/php/includes/header.php
@@ -1,0 +1,15 @@
+<?php if (!(is_front_page(  ))):
+	$titleEn = get_post_meta( get_the_ID(), 'title_english', true );
+	$titleDesc = get_post_meta( get_the_ID(), 'title_description', true );
+	$img = get_eyecatch_default();
+?>
+<!-- フロントページ以外のヘッダーのパーツ -->
+<!-- マークアップは仮です。 -->
+<header class="masthead" style="background-image: url('<?php echo $img[0];?>')">
+	<h1 class="c-title--header" title-english="<?php echo esc_attr($titleEn)?>"> <?php the_title( );?></h1>
+	<p><?php echo $titleDesc?></p>
+</header>
+<!-- フロントページのヘッダーのパーツ -->
+<?php else:?>
+	<h1>こちらはフロントページのヘッダー</h1>
+<?php endif;?>

--- a/wp-content/themes/urushitoki/production/php/index.php
+++ b/wp-content/themes/urushitoki/production/php/index.php
@@ -1,8 +1,7 @@
 <?php get_header(); ?>
 <body>
-	<header>
-		<h1 class="test-header">テスト</h1>
-	</header>
+	<!-- ヘッダーのフロントに表示 -->
+	<?php get_template_part('/includes/header')?>
 	<article class="documentClass">
     	<h1>Css Test</h1>
 	</article>


### PR DESCRIPTION
最終的には`<h1 class="test-header">テスト</h1>`を削除してパーツファイルのみにします。