### PR TITLE
カスタムフィールドの値の有無によって出力する文を切り替え

### DIFF
--- a/wp-content/themes/urushitoki/includes/header.php
+++ b/wp-content/themes/urushitoki/includes/header.php
@@ -6,8 +6,22 @@
 <!-- フロントページ以外のヘッダーのパーツ -->
 <!-- マークアップは仮です。 -->
 <header class="masthead" style="background-image: url('<?php echo $img[0];?>')">
-	<h1 class="c-title--header" title-english="<?php echo esc_attr($titleEn)?>"> <?php the_title( );?></h1>
-	<p><?php echo $titleDesc?></p>
+	<h1 class="c-title--header" title-english="
+	<?php if($titleEn):?>
+		<?php echo esc_attr($titleEn)?>">
+	<?php else:?>
+		ページタイトルの英訳が入ります">
+	<?php endif;?>
+	<?php the_title( );?>
+	</h1>
+	<p>
+	<?php if($titleDesc):?>
+		<?php echo $titleDesc?>
+	<?php else:?>
+		ページの説明文が入ります
+	<?php endif;?>
+	</p>
+
 </header>
 <!-- フロントページのヘッダーのパーツ -->
 <?php else:?>

--- a/wp-content/themes/urushitoki/production/php/includes/header.php
+++ b/wp-content/themes/urushitoki/production/php/includes/header.php
@@ -6,8 +6,22 @@
 <!-- フロントページ以外のヘッダーのパーツ -->
 <!-- マークアップは仮です。 -->
 <header class="masthead" style="background-image: url('<?php echo $img[0];?>')">
-	<h1 class="c-title--header" title-english="<?php echo esc_attr($titleEn)?>"> <?php the_title( );?></h1>
-	<p><?php echo $titleDesc?></p>
+	<h1 class="c-title--header" title-english="
+	<?php if($titleEn):?>
+		<?php echo esc_attr($titleEn)?>">
+	<?php else:?>
+		ページタイトルの英訳が入ります">
+	<?php endif;?>
+	<?php the_title( );?>
+	</h1>
+	<p>
+	<?php if($titleDesc):?>
+		<?php echo $titleDesc?>
+	<?php else:?>
+		ページの説明文が入ります
+	<?php endif;?>
+	</p>
+
 </header>
 <!-- フロントページのヘッダーのパーツ -->
 <?php else:?>


### PR DESCRIPTION
カスタムフィールドの値の有無による文の表示を切り替えを追加しました。
値がない時に非表示にするとヘッダーの余白のスタイリングが崩れる可能性があるかと思い、とりあえず仮の文字を出力するようにしてあります。ヘッダーの余白をどうスタイリングするかが確定次第、非表示とするかどうか再度見直します。