### PR TITLE
_preview.hbsの記述を変更後の内容に合わせる

### DIFF
--- a/wp-content/themes/urushitoki/src/styleguide/_preview.hbs
+++ b/wp-content/themes/urushitoki/src/styleguide/_preview.hbs
@@ -1,12 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
+
+<head>
   <meta charset="utf-8">
+  <link media="all" rel="stylesheet" href="{{ path '/css/ress.css' }}">
   <link media="all" rel="stylesheet" href="{{ path '/css/style.css' }}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css">
   <title>Preview Layout</title>
-  </head>
-  <body>
-    {{{ yield }}}
-    <script src="{{ path '../../js/index.js' }}"></script>
-  </body>
+</head>
+
+<body>
+  {{{ yield }}}
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"
+    integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+  <script src="{{ path '../../js/index.js' }}"></script>
+
+</body>
+
 </html>


### PR DESCRIPTION
styleguide直下の_preview.hbsの内容をsrc/styleguide/componentsディレクトリの中にある_preview.hbsに合わせました。

スタイルガイドでprojectが作成されるように、_preview.hbsをsrc/styleguide/componentsからsrc/styleguide/ディレクトリの中に移動させました。
これにより、スタイルガイドが動いたときに読みに行くのがsyleguide直下の_preview.hbsになると思います。
私が移動させたのと同時進行で、src/styleguide/componentsの_preview.hbsの記述が更新されていました。移動させたhbsファイルの記述も更新したほうがよいと思った次第です。

よろしくお願いいたします。