### PR TITLE
文様の種類を七宝から竜胆に変更

### DIFF
--- a/wp-content/themes/urushitoki/src/styleguide/components/pattern/pattern.hbs
+++ b/wp-content/themes/urushitoki/src/styleguide/components/pattern/pattern.hbs
@@ -1,8 +1,8 @@
 <div class="c-pattern">
-	<img class="c-pattern__layer--left" src="../raw/pattern/monyou01.png" alt="">
+	<img class="c-pattern__layer--left" src="../raw/pattern/monyou02.png" alt="">
 	<img class="c-pattern__image" src="../raw/pattern/20.jpg" alt="">
 </div>
 <div class="c-pattern">
-	<img class="c-pattern__layer--right" src="../raw/pattern/monyou01.png" alt="">
+	<img class="c-pattern__layer--right" src="../raw/pattern/monyou02.png" alt="">
 	<img class="c-pattern__image" src="../raw/pattern/07.jpg" alt="">
 </div>


### PR DESCRIPTION
定例MTGでお話のありました`c-pattern`コンポーネントの修正です。
レイヤーとして使用する文様を七宝から竜胆に変更しました。
よろしくお願いいたします。