### PR TITLE
menu外部リンク変数初期化忘れ修正

### DIFF
--- a/wp-content/themes/urushitoki/includes/nav-menu.php
+++ b/wp-content/themes/urushitoki/includes/nav-menu.php
@@ -13,12 +13,14 @@
 			$target     = $menu_item->target;
 			if($target != ""){
 				$add_class = ' blank-link';
-				$blank = 'target="_blank" rel="noopener noreferrer"';
+				$blank     = 'target = "_blank" rel = "noopener noreferrer"';
 			}
 			$menu_list .=
 			'<li class="'. $menu_name . '_list'. $add_class .'" title="'. $attr_title .'">
 			<a href="' . esc_attr($url) . '"'. $blank .'>' . esc_html($title) . '</a>
 			</li>';
+			$add_class = "";
+			$blank     = "";
 		}
 		$menu_list .= '</ul>';
 	} else {

--- a/wp-content/themes/urushitoki/production/php/includes/nav-menu.php
+++ b/wp-content/themes/urushitoki/production/php/includes/nav-menu.php
@@ -13,12 +13,14 @@
 			$target     = $menu_item->target;
 			if($target != ""){
 				$add_class = ' blank-link';
-				$blank = 'target="_blank" rel="noopener noreferrer"';
+				$blank     = 'target = "_blank" rel = "noopener noreferrer"';
 			}
 			$menu_list .=
 			'<li class="'. $menu_name . '_list'. $add_class .'" title="'. $attr_title .'">
 			<a href="' . esc_attr($url) . '"'. $blank .'>' . esc_html($title) . '</a>
 			</li>';
+			$add_class = "";
+			$blank     = "";
 		}
 		$menu_list .= '</ul>';
 	} else {


### PR DESCRIPTION
メニューの外部リンク用変数の初期化を忘れていたため、
一度別タブで開く外部リンクに飛ぶ項目後は、
全て別タブで開かれてしまう不具合が発生していたため修正いたしました。