### PR TITLE
カスタムブロックでのstyle修正

### DIFF
--- a/wp-content/plugins/stack-media-text/build/index.asset.php
+++ b/wp-content/plugins/stack-media-text/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n'), 'version' => 'ef3fd409c083935db083f9ebd17bb4c1');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n'), 'version' => 'c8f39e71d84155ae6d7a0b0c28f0d53b');

--- a/wp-content/plugins/stack-media-text/build/index.js
+++ b/wp-content/plugins/stack-media-text/build/index.js
@@ -164,7 +164,7 @@ __webpack_require__.r(__webpack_exports__);
     return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", blockProps, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("h3", {
       className: "c-title-large"
     }, attributes.title), getImagesSave(attributes.mediaURL, attributes.mediaAlt), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("p", {
-      className: "c-text--white"
+      className: "c-text--white text-background"
     }, attributes.description));
   }
 });

--- a/wp-content/plugins/stack-media-text/build/style-index.css
+++ b/wp-content/plugins/stack-media-text/build/style-index.css
@@ -10,7 +10,7 @@
 /*
 .wp-block-create-block-stack-media-text {}
 */
-.c-text--white {
+.text-background {
   background-color: #210c02;
 }
 

--- a/wp-content/plugins/stack-media-text/src/index.js
+++ b/wp-content/plugins/stack-media-text/src/index.js
@@ -152,7 +152,7 @@ registerBlockType( 'create-block/stack-media-text', {
 				<div {...blockProps}>
 					<h3 className="c-title-large">{ attributes.title }</h3>
 					{ getImagesSave(attributes.mediaURL, attributes.mediaAlt) }
-					<p className="c-text--white">{ attributes.description }</p>
+					<p className="c-text--white text-background">{ attributes.description }</p>
 				</div>
 		);
 	},

--- a/wp-content/plugins/stack-media-text/src/style.scss
+++ b/wp-content/plugins/stack-media-text/src/style.scss
@@ -10,6 +10,6 @@
 */
 
 
-.c-text--white{
+.text-background{
 	background-color: rgba(33,12,2,1.0);
 }


### PR DESCRIPTION
カスタムブロックのstyle.cssでc-text--whiteに背景色のスタイルを適用していたことが原因で、
他のc-text--whiteにも適用されてしまっていたため、修正いたしました。