### PR TITLE
背景付きテキスト/画像 スタイル適用

### DIFF
--- a/wp-content/plugins/background-text/build/index.asset.php
+++ b/wp-content/plugins/background-text/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n'), 'version' => 'afd795c84fc8d59f39498f590bccc1b5');
+<?php return array('dependencies' => array('wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n'), 'version' => '1cbfa85ae2883d5daf0e2a7d90f815f3');

--- a/wp-content/plugins/background-text/build/index.css
+++ b/wp-content/plugins/background-text/build/index.css
@@ -10,4 +10,8 @@
   border: 1px solid #999;
 }
 
+.block-editor-rich-text__editable.c-title-small--center {
+  color: #fff;
+}
+
 /*# sourceMappingURL=index.css.map*/

--- a/wp-content/plugins/background-text/build/index.js
+++ b/wp-content/plugins/background-text/build/index.js
@@ -15,13 +15,12 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _wordpress_blocks__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_wordpress_blocks__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @wordpress/i18n */ "@wordpress/i18n");
 /* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
-/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/block-editor */ "@wordpress/block-editor");
-/* harmony import */ var _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @wordpress/block-editor */ "@wordpress/block-editor");
+/* harmony import */ var _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @wordpress/components */ "@wordpress/components");
+/* harmony import */ var _wordpress_components__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__);
 /* harmony import */ var _style_scss__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./style.scss */ "./src/style.scss");
 /* harmony import */ var _editor_scss__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./editor.scss */ "./src/editor.scss");
-
 
 
 
@@ -33,13 +32,11 @@ __webpack_require__.r(__webpack_exports__);
   attributes: {
     title: {
       type: 'string',
-      source: 'text',
-      selector: 'dt.c-title-small--center'
+      default: ''
     },
     description: {
       type: 'string',
-      source: 'text',
-      selector: 'dd.c-text--white'
+      default: ''
     },
     mediaID: {
       type: 'number',
@@ -65,11 +62,14 @@ __webpack_require__.r(__webpack_exports__);
     } = _ref;
     const {
       title,
-      description,
       mediaURL,
       mediaID,
       mediaAlt
     } = attributes;
+    const description = [["core/paragraph", {
+      className: "c-text--white",
+      placeholder: "説明が入ります。"
+    }]];
 
     const onSelectImage = media => {
       setAttributes({
@@ -89,7 +89,7 @@ __webpack_require__.r(__webpack_exports__);
       } else {
         return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("div", {
           className: "button-container"
-        }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_3__.Button, {
+        }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
           onClick: open,
           className: "button button-large"
         }, "\u753B\u50CF\u3092\u30A2\u30C3\u30D7\u30ED\u30FC\u30C9"));
@@ -104,22 +104,28 @@ __webpack_require__.r(__webpack_exports__);
       });
     };
 
-    const blockProps = (0,_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__.useBlockProps)({
+    const blockProps = (0,_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.useBlockProps)({
       className: 'p-contents-card'
     });
-    return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("figure", blockProps, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dl", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_3__.TextControl, {
-      placeholder: "\u30BF\u30A4\u30C8\u30EB",
+    return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("figure", blockProps, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dl", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dt", {
+      className: "p-contents-card__title"
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.RichText, {
+      tagName: "h4",
+      className: "c-title-small--center",
+      placeholder: "\u30BF\u30A4\u30C8\u30EB\u304C\u5165\u308A\u307E\u3059\u3002",
+      keepPlaceholderOnFocus: true,
       value: title,
-      onChange: value => setAttributes({
-        title: value
+      onChange: newTitle => setAttributes({
+        title: newTitle
       })
-    }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_3__.TextareaControl, {
-      placeholder: "\u8AAC\u660E",
-      value: description,
-      onChange: value => setAttributes({
-        description: value
-      })
-    }), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__.MediaUploadCheck, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__.MediaUpload, {
+    })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", {
+      className: "p-contents-card__text"
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.InnerBlocks, {
+      template: description,
+      templateLock: "all"
+    })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", {
+      className: "p-contents-card__image"
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.MediaUploadCheck, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.MediaUpload, {
       onSelect: onSelectImage,
       allowedTypes: ['image'],
       value: mediaID,
@@ -129,10 +135,10 @@ __webpack_require__.r(__webpack_exports__);
         } = _ref2;
         return getImageButton(open);
       }
-    })), mediaID != 0 && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__.MediaUploadCheck, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_3__.Button, {
+    }))), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", null, mediaID != 0 && (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.MediaUploadCheck, null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_components__WEBPACK_IMPORTED_MODULE_4__.Button, {
       onClick: removeMedia,
       className: "button button-large"
-    }, "\u753B\u50CF\u3092\u524A\u9664"))));
+    }, "\u753B\u50CF\u3092\u524A\u9664")))));
   },
   save: _ref3 => {
     let {
@@ -156,14 +162,20 @@ __webpack_require__.r(__webpack_exports__);
       });
     };
 
-    const blockProps = _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_4__.useBlockProps.save({
+    const blockProps = _wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.useBlockProps.save({
       className: 'p-contents-card'
     });
     return (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("figure", blockProps, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dl", null, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dt", {
-      className: "c-title-small--center"
-    }, attributes.title), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", {
-      className: "c-text--white"
-    }, attributes.description)), getImagesSave(attributes.mediaURL, attributes.mediaAlt));
+      className: "p-contents-card__title"
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.RichText.Content, {
+      tagName: "h4",
+      className: "c-title-small--center",
+      value: attributes.title
+    })), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", {
+      className: "p-contents-card__text"
+    }, (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)(_wordpress_block_editor__WEBPACK_IMPORTED_MODULE_3__.InnerBlocks.Content, null)), (0,_wordpress_element__WEBPACK_IMPORTED_MODULE_0__.createElement)("dd", {
+      className: "p-contents-card__image"
+    }, getImagesSave(attributes.mediaURL, attributes.mediaAlt))));
   }
 });
 

--- a/wp-content/plugins/background-text/src/editor.scss
+++ b/wp-content/plugins/background-text/src/editor.scss
@@ -6,3 +6,6 @@
 .wp-block-background-text {
 	border: 1px solid #999;
 }
+.block-editor-rich-text__editable.c-title-small--center{
+	color: #fff;
+}

--- a/wp-content/plugins/background-text/src/index.js
+++ b/wp-content/plugins/background-text/src/index.js
@@ -1,10 +1,8 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import {
-	TextControl,
-	TextareaControl,
-} from '@wordpress/components';
-import {
+	InnerBlocks,
+	RichText,
 	MediaUpload,
 	MediaUploadCheck,
 	useBlockProps
@@ -16,14 +14,12 @@ import './editor.scss';
 registerBlockType( 'create-block/background-text', {
 	attributes: {
 		title: {
-			type    : 'string',
-			source  : 'text',
-			selector: 'dt.c-title-small--center',
+			type   : 'string',
+			default: ''
 		},
 		description: {
-			type    : 'string',
-			source  : 'text',
-			selector: 'dd.c-text--white',
+			type   : 'string',
+			default: ''
 		},
 		mediaID: {
             type: 'number',
@@ -46,11 +42,19 @@ registerBlockType( 'create-block/background-text', {
 	edit: ( { attributes, setAttributes } ) => {
 		const {
 			title,
-			description,
 			mediaURL,
 			mediaID,
 			mediaAlt
 		} = attributes;
+		const description = [
+			[
+				"core/paragraph",
+				{
+					className: "c-text--white",
+					placeholder: "説明が入ります。",
+				},
+			],
+		];
 		const onSelectImage = ( media ) => {
             setAttributes( {
                 mediaURL: media.url,
@@ -91,36 +95,44 @@ registerBlockType( 'create-block/background-text', {
 		const blockProps = useBlockProps( {
 			className: 'p-contents-card',
 		} );
+
 		return (
 			<figure { ...blockProps }>
 				<dl>
-					<TextControl
-						placeholder="タイトル"
-						value={ title }
-						onChange={( value ) => setAttributes( { title: value } )}
-					/>
-					<TextareaControl
-						placeholder="説明"
-						value={ description }
-						onChange={ ( value ) => setAttributes({ description: value })}
-					/>
-					<MediaUploadCheck>
-						<MediaUpload
-							onSelect={ onSelectImage }
-							allowedTypes={ ['image'] }
-							value={ mediaID }
-							render={ ({ open }) => getImageButton( open ) }
+					<dt className="p-contents-card__title">
+						<RichText
+							tagName                = "h4"
+							className              = "c-title-small--center"
+							placeholder            = "タイトルが入ります。"
+							keepPlaceholderOnFocus = { true }
+							value                  = { title }
+							onChange               = { ( newTitle ) => setAttributes({ title: newTitle })}
 						/>
-					</MediaUploadCheck>
-					{ mediaID != 0  &&
+					</dt>
+					<dd className="p-contents-card__text">
+						<InnerBlocks template= { description } templateLock="all" />
+					</dd>
+					<dd className="p-contents-card__image">
 						<MediaUploadCheck>
-							<Button
-							onClick={removeMedia}
-							className="button button-large">
-							画像を削除
-							</Button>
+							<MediaUpload
+								onSelect     = { onSelectImage }
+								allowedTypes = { ['image'] }
+								value        = { mediaID }
+								render       = { ({ open }) => getImageButton( open ) }
+							/>
 						</MediaUploadCheck>
-					}
+					</dd>
+					<dd>
+						{ mediaID != 0  &&
+							<MediaUploadCheck>
+								<Button
+								onClick   = {removeMedia}
+								className = "button button-large">
+								画像を削除
+								</Button>
+							</MediaUploadCheck>
+						}
+					</dd>
 				</dl>
 			</figure>
 		);
@@ -151,10 +163,20 @@ registerBlockType( 'create-block/background-text', {
 		return (
 				<figure {...blockProps}>
 					<dl>
-						<dt className="c-title-small--center">{ attributes.title }</dt>
-						<dd className="c-text--white">{ attributes.description }</dd>
+						<dt className="p-contents-card__title">
+							<RichText.Content
+								tagName   = "h4"
+								className = "c-title-small--center"
+								value     = { attributes.title }
+							/>
+						</dt>
+						<dd className="p-contents-card__text">
+							<InnerBlocks.Content />
+						</dd>
+						<dd className="p-contents-card__image">
+							{ getImagesSave(attributes.mediaURL, attributes.mediaAlt) }
+						</dd>
 					</dl>
-					{ getImagesSave(attributes.mediaURL, attributes.mediaAlt) }
 				</figure>
 		);
 	},


### PR DESCRIPTION
カスタムブロックの背景付きテキスト画像にstyleguideのスタイルを適用しました。

今まで使用していたTextareaControlでは改行が反映できなかったため、
タイトル部をRichText、説明部を既存の段落に置き換えています。