### PR TITLE
#301 コンポーネント・タイトル：c-title-smallの余白修正

### DIFF
--- a/wp-content/themes/urushitoki/css/editor-style.css
+++ b/wp-content/themes/urushitoki/css/editor-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/css/style.css
+++ b/wp-content/themes/urushitoki/css/style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center {

--- a/wp-content/themes/urushitoki/css/urushidoki-block-style.css
+++ b/wp-content/themes/urushitoki/css/urushidoki-block-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/htdocs/assets/css/editor-style.css
+++ b/wp-content/themes/urushitoki/htdocs/assets/css/editor-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/htdocs/assets/css/style.css
+++ b/wp-content/themes/urushitoki/htdocs/assets/css/style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center {

--- a/wp-content/themes/urushitoki/htdocs/assets/css/urushidoki-block-style.css
+++ b/wp-content/themes/urushitoki/htdocs/assets/css/urushidoki-block-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/production/sass/object/component/_title.scss
+++ b/wp-content/themes/urushitoki/production/sass/object/component/_title.scss
@@ -76,7 +76,11 @@
 		display       : block;
 		border-bottom : solid 3px variable.$border-color--main;
 		width         : 80px;       // 線の長さ
-		margin-top    : 44px;       // タイトルとの余白
+		margin-top    : 30px;       // タイトルとの余白
+		/* レスポンシブ（タイトルとの余白） */
+		@include mixin.breakpoint( breakpoint-tab ){
+			margin-top: 20px;
+		}
 	}
 }
 
@@ -94,7 +98,7 @@
 		border-bottom : solid 3px variable.$border-color--main;
 		width         : 80px;       // 線の長さ
 		margin-top    : 44px;       // タイトルとの余白
-}
+	}
 }
 
 .c-title-noborder{

--- a/wp-content/themes/urushitoki/src/sass/object/component/_title.scss
+++ b/wp-content/themes/urushitoki/src/sass/object/component/_title.scss
@@ -3,104 +3,108 @@
 @use "../../foundation/mixin";
 
 .c-title{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size      : variable.$font-size--title-large--pc;
-    color          : variable.$font-color--main;
-    width          : 100%;
-    padding-bottom : 10px;
-    /* レスポンシブ（タイトルとの余白） */
-    @include mixin.breakpoint( breakpoint-tab ){
-        padding-bottom: 20px;
-    }
-    @include mixin.breakpoint( breakpoint-sp ){
-        padding-bottom: 15px;
-    }
-    border-bottom  : solid 4px variable.$border-color--main;   // 線種、太さ、色
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size      : variable.$font-size--title-large--pc;
+	color          : variable.$font-color--main;
+	width          : 100%;
+	padding-bottom : 10px;
+	/* レスポンシブ（タイトルとの余白） */
+	@include mixin.breakpoint( breakpoint-tab ){
+		padding-bottom: 20px;
+	}
+	@include mixin.breakpoint( breakpoint-sp ){
+		padding-bottom: 15px;
+	}
+	border-bottom  : solid 4px variable.$border-color--main;   // 線種、太さ、色
 
-    /* Englishタイトル */
-    &--header{
-        @extend .c-title;
-        &::before{
-            content       : attr(title-english);    // アトリビュート
-            display       : block;
-            font-size     : variable.$font-size--title-large--header--pc;
-            margin-bottom : 50px;       // タイトルとの余白
-        }
-    }
-    /* 罫線のアクセントカラー設定 */
-    &::after{
-        content       : "";
-        position      : absolute;
-        display       : block;
-        border-bottom : solid 4px variable.$border-color--accent;   // 線種、太さ、色
-        width         : 42px;
-        padding-top   : 10px;   // タイトルとの余白
-        /* レスポンシブ（タイトルとの余白） */
-        @include mixin.breakpoint( breakpoint-tab ){
-            padding-top: 20px;
-        }
-        @include mixin.breakpoint( breakpoint-sp ){
-            padding-top: 15px;
-        }
-    }
+	/* Englishタイトル */
+	&--header{
+		@extend .c-title;
+		&::before{
+			content       : attr(title-english);    // アトリビュート
+			display       : block;
+			font-size     : variable.$font-size--title-large--header--pc;
+			margin-bottom : 50px;       // タイトルとの余白
+		}
+	}
+	/* 罫線のアクセントカラー設定 */
+	&::after{
+		content       : "";
+		position      : absolute;
+		display       : block;
+		border-bottom : solid 4px variable.$border-color--accent;   // 線種、太さ、色
+		width         : 42px;
+		padding-top   : 10px;   // タイトルとの余白
+		/* レスポンシブ（タイトルとの余白） */
+		@include mixin.breakpoint( breakpoint-tab ){
+			padding-top: 20px;
+		}
+		@include mixin.breakpoint( breakpoint-sp ){
+			padding-top: 15px;
+		}
+	}
 }
 
 .c-title-large {
-    position        : relative;
-    @include mixin.font-yumincho;
-    font-size       : variable.$font-size--title-large--pc;
-    color           : variable.$font-color--main;
-    width           : 100%;
-    padding-bottom  : 46px;
-    border-bottom   : solid 4px variable.$border-color--main;
-    /* 罫線のアクセントカラー設定 */
-    &::after{
-        content       : "";
-        position      : absolute;
-        display       : block;
-        border-bottom : solid 4px variable.$border-color--accent;
-        width         : 42px;
-        padding-top   : 46px;
-    }
+	position        : relative;
+	@include mixin.font-yumincho;
+	font-size       : variable.$font-size--title-large--pc;
+	color           : variable.$font-color--main;
+	width           : 100%;
+	padding-bottom  : 46px;
+	border-bottom   : solid 4px variable.$border-color--main;
+	/* 罫線のアクセントカラー設定 */
+	&::after{
+		content       : "";
+		position      : absolute;
+		display       : block;
+		border-bottom : solid 4px variable.$border-color--accent;
+		width         : 42px;
+		padding-top   : 46px;
+	}
 }
 
 .c-title-small{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size : variable.$font-size--title-small--pc;
-    color     : variable.$font-color--main;
-    /* 罫線 */
-    &::after{
-        content       : "";
-        display       : block;
-        border-bottom : solid 3px variable.$border-color--main;
-        width         : 80px;       // 線の長さ
-        margin-top    : 44px;       // タイトルとの余白
-    }
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size : variable.$font-size--title-small--pc;
+	color     : variable.$font-color--main;
+	/* 罫線 */
+	&::after{
+		content       : "";
+		display       : block;
+		border-bottom : solid 3px variable.$border-color--main;
+		width         : 80px;       // 線の長さ
+		margin-top    : 30px;       // タイトルとの余白
+		/* レスポンシブ（タイトルとの余白） */
+		@include mixin.breakpoint( breakpoint-tab ){
+			margin-top: 20px;
+		}
+	}
 }
 
 .c-title-small--center{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size  : variable.$font-size--title-small--pc;
-    text-align : center;
-    color      : variable.$font-color--sub;
-    /* 罫線 */
-    &::after{
-        content       : "";
-        display       : block;
-        margin        : auto;
-        border-bottom : solid 3px variable.$border-color--main;
-        width         : 80px;       // 線の長さ
-        margin-top    : 44px;       // タイトルとの余白
-    }
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size  : variable.$font-size--title-small--pc;
+	text-align : center;
+	color      : variable.$font-color--sub;
+	/* 罫線 */
+	&::after{
+		content       : "";
+		display       : block;
+		margin        : auto;
+		border-bottom : solid 3px variable.$border-color--main;
+		width         : 80px;       // 線の長さ
+		margin-top    : 44px;       // タイトルとの余白
+	}
 }
 
 .c-title-noborder{
-    position    : relative;
-    font-size   : variable.$font-size--title-noborder--pc;
-    font-weight : variable.$font-weight--bold;
-    text-align  : center;
-    color       : variable.$font-color--third;
+	position    : relative;
+	font-size   : variable.$font-size--title-noborder--pc;
+	font-weight : variable.$font-weight--bold;
+	text-align  : center;
+	color       : variable.$font-color--third;
 }

--- a/wp-content/themes/urushitoki/src/styleguide/components/title/style.scss
+++ b/wp-content/themes/urushitoki/src/styleguide/components/title/style.scss
@@ -3,104 +3,108 @@
 @use "../../foundation/mixin";
 
 .c-title{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size      : variable.$font-size--title-large--pc;
-    color          : variable.$font-color--main;
-    width          : 100%;
-    padding-bottom : 10px;
-    /* レスポンシブ（タイトルとの余白） */
-    @include mixin.breakpoint( breakpoint-tab ){
-        padding-bottom: 20px;
-    }
-    @include mixin.breakpoint( breakpoint-sp ){
-        padding-bottom: 15px;
-    }
-    border-bottom  : solid 4px variable.$border-color--main;   // 線種、太さ、色
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size      : variable.$font-size--title-large--pc;
+	color          : variable.$font-color--main;
+	width          : 100%;
+	padding-bottom : 10px;
+	/* レスポンシブ（タイトルとの余白） */
+	@include mixin.breakpoint( breakpoint-tab ){
+		padding-bottom: 20px;
+	}
+	@include mixin.breakpoint( breakpoint-sp ){
+		padding-bottom: 15px;
+	}
+	border-bottom  : solid 4px variable.$border-color--main;   // 線種、太さ、色
 
-    /* Englishタイトル */
-    &--header{
-        @extend .c-title;
-        &::before{
-            content       : attr(title-english);    // アトリビュート
-            display       : block;
-            font-size     : variable.$font-size--title-large--header--pc;
-            margin-bottom : 50px;       // タイトルとの余白
-        }
-    }
-    /* 罫線のアクセントカラー設定 */
-    &::after{
-        content       : "";
-        position      : absolute;
-        display       : block;
-        border-bottom : solid 4px variable.$border-color--accent;   // 線種、太さ、色
-        width         : 42px;
-        padding-top   : 10px;   // タイトルとの余白
-        /* レスポンシブ（タイトルとの余白） */
-        @include mixin.breakpoint( breakpoint-tab ){
-            padding-top: 20px;
-        }
-        @include mixin.breakpoint( breakpoint-sp ){
-            padding-top: 15px;
-        }
-    }
+	/* Englishタイトル */
+	&--header{
+		@extend .c-title;
+		&::before{
+			content       : attr(title-english);    // アトリビュート
+			display       : block;
+			font-size     : variable.$font-size--title-large--header--pc;
+			margin-bottom : 50px;       // タイトルとの余白
+		}
+	}
+	/* 罫線のアクセントカラー設定 */
+	&::after{
+		content       : "";
+		position      : absolute;
+		display       : block;
+		border-bottom : solid 4px variable.$border-color--accent;   // 線種、太さ、色
+		width         : 42px;
+		padding-top   : 10px;   // タイトルとの余白
+		/* レスポンシブ（タイトルとの余白） */
+		@include mixin.breakpoint( breakpoint-tab ){
+			padding-top: 20px;
+		}
+		@include mixin.breakpoint( breakpoint-sp ){
+			padding-top: 15px;
+		}
+	}
 }
 
 .c-title-large {
-    position        : relative;
-    @include mixin.font-yumincho;
-    font-size       : variable.$font-size--title-large--pc;
-    color           : variable.$font-color--main;
-    width           : 100%;
-    padding-bottom  : 46px;
-    border-bottom   : solid 4px variable.$border-color--main;
-    /* 罫線のアクセントカラー設定 */
-    &::after{
-        content       : "";
-        position      : absolute;
-        display       : block;
-        border-bottom : solid 4px variable.$border-color--accent;
-        width         : 42px;
-        padding-top   : 46px;
-    }
+	position        : relative;
+	@include mixin.font-yumincho;
+	font-size       : variable.$font-size--title-large--pc;
+	color           : variable.$font-color--main;
+	width           : 100%;
+	padding-bottom  : 46px;
+	border-bottom   : solid 4px variable.$border-color--main;
+	/* 罫線のアクセントカラー設定 */
+	&::after{
+		content       : "";
+		position      : absolute;
+		display       : block;
+		border-bottom : solid 4px variable.$border-color--accent;
+		width         : 42px;
+		padding-top   : 46px;
+	}
 }
 
 .c-title-small{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size : variable.$font-size--title-small--pc;
-    color     : variable.$font-color--main;
-    /* 罫線 */
-    &::after{
-        content       : "";
-        display       : block;
-        border-bottom : solid 3px variable.$border-color--main;
-        width         : 80px;       // 線の長さ
-        margin-top    : 44px;       // タイトルとの余白
-    }
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size : variable.$font-size--title-small--pc;
+	color     : variable.$font-color--main;
+	/* 罫線 */
+	&::after{
+		content       : "";
+		display       : block;
+		border-bottom : solid 3px variable.$border-color--main;
+		width         : 80px;       // 線の長さ
+		margin-top    : 30px;       // タイトルとの余白
+		/* レスポンシブ（タイトルとの余白） */
+		@include mixin.breakpoint( breakpoint-tab ){
+			margin-top: 20px;
+		}
+	}
 }
 
 .c-title-small--center{
-    position       : relative;
-    @include mixin.font-yumincho;
-    font-size  : variable.$font-size--title-small--pc;
-    text-align : center;
-    color      : variable.$font-color--sub;
-    /* 罫線 */
-    &::after{
-        content       : "";
-        display       : block;
-        margin        : auto;
-        border-bottom : solid 3px variable.$border-color--main;
-        width         : 80px;       // 線の長さ
-        margin-top    : 44px;       // タイトルとの余白
-    }
+	position       : relative;
+	@include mixin.font-yumincho;
+	font-size  : variable.$font-size--title-small--pc;
+	text-align : center;
+	color      : variable.$font-color--sub;
+	/* 罫線 */
+	&::after{
+		content       : "";
+		display       : block;
+		margin        : auto;
+		border-bottom : solid 3px variable.$border-color--main;
+		width         : 80px;       // 線の長さ
+		margin-top    : 44px;       // タイトルとの余白
+	}
 }
 
 .c-title-noborder{
-    position    : relative;
-    font-size   : variable.$font-size--title-noborder--pc;
-    font-weight : variable.$font-weight--bold;
-    text-align  : center;
-    color       : variable.$font-color--third;
+	position    : relative;
+	font-size   : variable.$font-size--title-noborder--pc;
+	font-weight : variable.$font-weight--bold;
+	text-align  : center;
+	color       : variable.$font-color--third;
 }

--- a/wp-content/themes/urushitoki/styleguide/components/detail/article-card.html
+++ b/wp-content/themes/urushitoki/styleguide/components/detail/article-card.html
@@ -1043,8 +1043,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>

--- a/wp-content/themes/urushitoki/styleguide/components/detail/bullet.html
+++ b/wp-content/themes/urushitoki/styleguide/components/detail/bullet.html
@@ -993,8 +993,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>

--- a/wp-content/themes/urushitoki/styleguide/components/detail/pattern.html
+++ b/wp-content/themes/urushitoki/styleguide/components/detail/pattern.html
@@ -1124,8 +1124,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>

--- a/wp-content/themes/urushitoki/styleguide/components/detail/post-card.html
+++ b/wp-content/themes/urushitoki/styleguide/components/detail/post-card.html
@@ -1059,8 +1059,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>

--- a/wp-content/themes/urushitoki/styleguide/components/detail/preview.html
+++ b/wp-content/themes/urushitoki/styleguide/components/detail/preview.html
@@ -935,8 +935,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>

--- a/wp-content/themes/urushitoki/styleguide/css/editor-style.css
+++ b/wp-content/themes/urushitoki/styleguide/css/editor-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/styleguide/css/style.css
+++ b/wp-content/themes/urushitoki/styleguide/css/style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center {

--- a/wp-content/themes/urushitoki/styleguide/css/urushidoki-block-style.css
+++ b/wp-content/themes/urushitoki/styleguide/css/urushidoki-block-style.css
@@ -354,7 +354,15 @@ body {
   display: block;
   border-bottom: solid 3px #fff;
   width: 80px;
-  margin-top: 44px;
+  margin-top: 30px;
+  /* レスポンシブ（タイトルとの余白） */
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 1024px) {
+  .c-title-small::after, .is-style-c-title-small::after, .c-definition--shop-card__title::after {
+    margin-top: 20px;
+  }
 }
 
 .c-title-small--center, .is-style-c-title-small--center {

--- a/wp-content/themes/urushitoki/styleguide/index.html
+++ b/wp-content/themes/urushitoki/styleguide/index.html
@@ -734,8 +734,8 @@
                     <dt class="Tree-asideTerm">Built on:</dt>
                     <dd class="Tree-asideDescription">
                         
-                            <time datetime="2021-12-14T16:07:08.385Z">
-                                12/15/2021
+                            <time datetime="2021-12-16T06:10:16.866Z">
+                                12/16/2021
                             </time>
                         
                     </dd>


### PR DESCRIPTION
`margin-top: 44px;`
こちら、下線部とタイトルの間の余白でしたが、30pxに修正、レスポンシブでtab以下は20pxになるようにしました。