### PR TITLE
タグのpadding調整

### DIFF
--- a/wp-content/themes/urushitoki/production/sass/object/component/_tab.scss
+++ b/wp-content/themes/urushitoki/production/sass/object/component/_tab.scss
@@ -12,4 +12,6 @@
 	padding: 8px 10px;
 	text-align: center;
 	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
 }

--- a/wp-content/themes/urushitoki/src/sass/object/component/_tab.scss
+++ b/wp-content/themes/urushitoki/src/sass/object/component/_tab.scss
@@ -12,4 +12,6 @@
 	padding: 8px 10px;
 	text-align: center;
 	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
 }

--- a/wp-content/themes/urushitoki/src/styleguide/components/tab/style.scss
+++ b/wp-content/themes/urushitoki/src/styleguide/components/tab/style.scss
@@ -12,4 +12,6 @@
 	padding: 8px 10px;
 	text-align: center;
 	cursor: pointer;
+	font-size: 12px;
+	line-height: 1;
 }


### PR DESCRIPTION
タグの内側の余白が狭く見えるのはpaddingが小さいからではなく、フォントがカンプより大きかったためのようです。
フォントサイズを16px→12pxに変更しました。よろしくお願いいたします。