### PR TITLE
#343 aboutページの調整

### DIFF
--- a/wp-content/themes/urushitoki/includes/header.php
+++ b/wp-content/themes/urushitoki/includes/header.php
@@ -183,6 +183,9 @@
 		padding-top:200px;
 		padding-bottom:200px;
 	}
+	.l-main--about{
+		margin-top: 478px;
+	}
 	.p-post__tags{
 		gap:20px;
 

--- a/wp-content/themes/urushitoki/page-about.php
+++ b/wp-content/themes/urushitoki/page-about.php
@@ -3,100 +3,111 @@
 	<?php get_template_part('/includes/header')?>
 	<!-- メインコンテンツ -->
 	<main class="l-main">
-		<article class=c-wrapper>
-		<!-- 記述内容の表示 -->
-		<?php get_template_part('/includes/have-post-loop');?>
+		<article class="c-wrapper">
+			<!-- 記述内容の表示 -->
+			<?php get_template_part('/includes/have-post-loop');?>
+			<!-- 記事内容との間隔調整 -->
+			<article class="l-main--about">
+				<!-- 見出しタイトル -->
+				<h2 class="c-title-large u-margin--small">うるしときの職人</h2>
+				<!-- うるしときの職人表示 -->
 
-			<!-- 見出しタイトル -->
-			<h2 class="c-title-large u-margin--small">うるしときの職人</h2>
-			<!-- うるしときの職人表示 -->
+				<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
+				foreach($users as $user) {// 職人データforeach -start-
+					$user_id = $user->ID;?>
 
-			<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
-			foreach($users as $user) {// 職人データforeach -start-
-				$user_id = $user->ID;?>
+					<?php /* 写真 写真がある場合のみタグを出力する */
+					if(SCF::get_user_meta($user_id,'user_photo') != ""){
+						$img = SCF::get_user_meta($user_id,'user_photo');
+						echo '<article class="p-craftman c-flex c-flex--center">';
+						echo '<div class="p-craftman__image">';
+						echo wp_get_attachment_image( $img , 'large' );
+						echo '</div>';
+					} ?>
 
-				<?php /* 写真 写真がある場合のみタグを出力する */
-				if(SCF::get_user_meta($user_id,'user_photo') != ""){
-					$img = SCF::get_user_meta($user_id,'user_photo');
-					echo '<article class="p-craftman c-flex c-flex--center">';
-					echo '<div class="p-craftman__image">';
-					echo wp_get_attachment_image( $img , 'large' );
-					echo '</div>';
-				} ?>
-
-				<?php if(get_the_author_meta('last_name',$user_id) != "" and get_the_author_meta('first_name',$user_id) != ""){ ?>
-					<div class="p-craftman__information">
-						<dl class="c-definition">
-							<!-- 名前 -->
-							<dt class="p-craftman__information__name c-definition__title c-flex c-flex--space-between">
-								<p><?php the_author_meta('last_name',$user_id); ?> <?php the_author_meta('first_name',$user_id); ?></p>
-								<?php /* SNS */
-								$group = SCF::get_user_meta($user_id,'sns');
-								foreach ((array)$group as $fields ) {
-									if($fields['sns_type'] != "" && $fields['sns_url'] != ""){
-										$my_sns = $fields['sns_type'];
-										echo '<div class="p-sns c-flex">';
-										if($my_sns == 'Instagram'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--insta" target="_blank" rel="noopener noreferrer">
-												<i class="fab fa-instagram"></i>
-												<span class="c-title__profile">Instagram</span>
-											</a>
-										<?php }
-										elseif($my_sns == 'Facebook'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" target="p-sns__button _blank" rel="noopener noreferrer">
-											<img src="facebook-icon" alt="facebook"></a>
-										<?php }
-										elseif($my_sns == 'YouTube'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--youtube" target="_blank" rel="noopener noreferrer">
-												<i class="fab fa-youtube"></i>
-												<span class="c-title__profile">YouTube</span>
-											</a>
-										<?php ; }
+					<?php if(get_the_author_meta('last_name',$user_id) != "" and get_the_author_meta('first_name',$user_id) != ""){ ?>
+						<div class="p-craftman__information">
+							<dl class="c-definition">
+								<!-- 名前 -->
+								<dt class="p-craftman__information__name c-definition__title c-flex c-flex--space-between">
+									<p><?php the_author_meta('last_name',$user_id); ?> <?php the_author_meta('first_name',$user_id); ?></p>
+									<?php /* SNS */
+									$group = SCF::get_user_meta($user_id,'sns');
+									if(SCF::get_user_meta($user_id,'sns_type') !=""){
+										echo '<div class="p-sns c-flex">' ;
+									} ?>
+									<?php foreach ((array)$group as $fields ) {
+												if($fields['sns_type'] != "" && $fields['sns_url'] != ""){
+													$my_sns = $fields['sns_type'];
+													if($my_sns == 'Instagram'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--insta" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-instagram"></i>
+														<span class="c-title__profile">Instagram</span>
+													</a>
+												<?php }
+												elseif($my_sns == 'Facebook'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--facebook" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-facebook-f"></i>
+														<span class="c-title__profile">Facebook</span>
+													</a>
+												<?php }
+												elseif($my_sns == 'YouTube'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--youtube" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-youtube"></i>
+														<span class="c-title__profile">YouTube</span>
+													</a>
+											<?php }
+										}
 									}
-								} ?>
-							</dt>
-						<!-- 経歴 -->
-						<?php if(SCF::get_user_meta($user_id,'career') != ""){
-							$group = SCF::get_user_meta($user_id,'career');
-							$last_year = 0;
-							foreach ((array)$group as $fields ) { ?>
-								<dd class="c-definition__detail">
-									<?php if($last_year != $fields['career_year'] && $fields['career_year'] !=""){ ?>
-										<p class="c-definition__detail__item"><?php echo $fields['career_year']; ?></p>
-									<?php } ?>
-									<p class="c-definition__detail__item"><?php echo $fields['career_detail']; ?></p>
-								</dd>
-								<?php $last_year = $fields['career_year'];
-							}
-						} ?>
-						</dl>
-				<?php } ?>
+									if(SCF::get_user_meta($user_id,'sns_type') !=""){
+										echo '</div>' ;
+									} ?>
+								</dt>
+							<!-- 経歴 -->
+							<?php if(SCF::get_user_meta($user_id,'career') != ""){
+								$group = SCF::get_user_meta($user_id,'career');
+								$last_year = 0;
+								foreach ((array)$group as $fields ) { ?>
+									<dd class="c-definition__detail">
+										<?php if($last_year != $fields['career_year'] && $fields['career_year'] !=""){ ?>
+											<p class="c-definition__detail__item"><?php echo $fields['career_year']; ?></p>
+										<?php } ?>
+										<p class="c-definition__detail__item"><?php echo $fields['career_detail']; ?></p>
+									</dd>
+									<?php $last_year = $fields['career_year'];
+								}
+							} ?>
+							</dl>
+					<?php } ?>
 
-				<?php /* 受賞 */
-				$group       = SCF::get_user_meta($user_id,'award');
-				$have_ul_tag = false;
-				foreach ((array)$group as $fields ) {
-					if($fields['award_detail'] != ""){
-						if(!$have_ul_tag){ ?>
-							<ul class="c-bullet">
-							<?php $have_ul_tag = true;
-						} ?>
-						<li class="c-bullet__item"><?php echo $fields['award_detail']; ?></li>
+					<?php /* 受賞 */
+					$group       = SCF::get_user_meta($user_id,'award');
+					$have_ul_tag = false;
+					foreach ((array)$group as $fields ) {
+						if($fields['award_detail'] != ""){
+							if(!$have_ul_tag){ ?>
+								<ul class="c-bullet">
+								<?php $have_ul_tag = true;
+							} ?>
+							<li class="c-bullet__item"><?php echo $fields['award_detail']; ?></li>
+						<?php }
+					}
+					if($have_ul_tag){ ?>
+						</ul>
+						</div>
 					<?php }
-				}
-				if($have_ul_tag){ ?>
-					</ul>
-					</div>
-				<?php }
-				//写真がある場合のみ閉じタグを出力する
-				if(SCF::get_user_meta($user_id,'user_photo') != ""){
-					echo '</article>';
-				}
-			} ?><!-- 職人データforeach -end- -->
+					//写真がある場合のみ閉じタグを出力する
+					if(SCF::get_user_meta($user_id,'user_photo') != ""){
+						echo '</article>';
+					}
+				} ?><!-- 職人データforeach -end- -->
+			</article>
 		</article>
 		<!-- うるしときの職人表示ここまで -->
 		<article class="c-wrapper">
 			<?php get_template_part('/includes/archive-shop');?>
 		</article>
 	</main>
+	<div class="c-background-icon__left--cloisonne">
+	</div>
 	<?php get_footer(); ?>

--- a/wp-content/themes/urushitoki/page-sns.php
+++ b/wp-content/themes/urushitoki/page-sns.php
@@ -3,7 +3,9 @@
 	<?php get_template_part('/includes/header')?>
 
 		<div class="c-wrapper">
-
+		<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
+		foreach($users as $user) {
+			$user_id = $user->ID;?>
 		<?php /* SNS */
 			$group = SCF::get_user_meta($user_id,'sns');
 			foreach ((array)$group as $fields ) {

--- a/wp-content/themes/urushitoki/production/php/includes/header.php
+++ b/wp-content/themes/urushitoki/production/php/includes/header.php
@@ -183,6 +183,9 @@
 		padding-top:200px;
 		padding-bottom:200px;
 	}
+	.l-main--about{
+		margin-top: 478px;
+	}
 	.p-post__tags{
 		gap:20px;
 

--- a/wp-content/themes/urushitoki/production/php/page-about.php
+++ b/wp-content/themes/urushitoki/production/php/page-about.php
@@ -3,100 +3,111 @@
 	<?php get_template_part('/includes/header')?>
 	<!-- メインコンテンツ -->
 	<main class="l-main">
-		<article class=c-wrapper>
-		<!-- 記述内容の表示 -->
-		<?php get_template_part('/includes/have-post-loop');?>
+		<article class="c-wrapper">
+			<!-- 記述内容の表示 -->
+			<?php get_template_part('/includes/have-post-loop');?>
+			<!-- 記事内容との間隔調整 -->
+			<article class="l-main--about">
+				<!-- 見出しタイトル -->
+				<h2 class="c-title-large u-margin--small">うるしときの職人</h2>
+				<!-- うるしときの職人表示 -->
 
-			<!-- 見出しタイトル -->
-			<h2 class="c-title-large u-margin--small">うるしときの職人</h2>
-			<!-- うるしときの職人表示 -->
+				<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
+				foreach($users as $user) {// 職人データforeach -start-
+					$user_id = $user->ID;?>
 
-			<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
-			foreach($users as $user) {// 職人データforeach -start-
-				$user_id = $user->ID;?>
+					<?php /* 写真 写真がある場合のみタグを出力する */
+					if(SCF::get_user_meta($user_id,'user_photo') != ""){
+						$img = SCF::get_user_meta($user_id,'user_photo');
+						echo '<article class="p-craftman c-flex c-flex--center">';
+						echo '<div class="p-craftman__image">';
+						echo wp_get_attachment_image( $img , 'large' );
+						echo '</div>';
+					} ?>
 
-				<?php /* 写真 写真がある場合のみタグを出力する */
-				if(SCF::get_user_meta($user_id,'user_photo') != ""){
-					$img = SCF::get_user_meta($user_id,'user_photo');
-					echo '<article class="p-craftman c-flex c-flex--center">';
-					echo '<div class="p-craftman__image">';
-					echo wp_get_attachment_image( $img , 'large' );
-					echo '</div>';
-				} ?>
-
-				<?php if(get_the_author_meta('last_name',$user_id) != "" and get_the_author_meta('first_name',$user_id) != ""){ ?>
-					<div class="p-craftman__information">
-						<dl class="c-definition">
-							<!-- 名前 -->
-							<dt class="p-craftman__information__name c-definition__title c-flex c-flex--space-between">
-								<p><?php the_author_meta('last_name',$user_id); ?> <?php the_author_meta('first_name',$user_id); ?></p>
-								<?php /* SNS */
-								$group = SCF::get_user_meta($user_id,'sns');
-								foreach ((array)$group as $fields ) {
-									if($fields['sns_type'] != "" && $fields['sns_url'] != ""){
-										$my_sns = $fields['sns_type'];
-										echo '<div class="p-sns c-flex">';
-										if($my_sns == 'Instagram'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--insta" target="_blank" rel="noopener noreferrer">
-												<i class="fab fa-instagram"></i>
-												<span class="c-title__profile">Instagram</span>
-											</a>
-										<?php }
-										elseif($my_sns == 'Facebook'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" target="p-sns__button _blank" rel="noopener noreferrer">
-											<img src="facebook-icon" alt="facebook"></a>
-										<?php }
-										elseif($my_sns == 'YouTube'){ ?>
-											<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--youtube" target="_blank" rel="noopener noreferrer">
-												<i class="fab fa-youtube"></i>
-												<span class="c-title__profile">YouTube</span>
-											</a>
-										<?php ; }
+					<?php if(get_the_author_meta('last_name',$user_id) != "" and get_the_author_meta('first_name',$user_id) != ""){ ?>
+						<div class="p-craftman__information">
+							<dl class="c-definition">
+								<!-- 名前 -->
+								<dt class="p-craftman__information__name c-definition__title c-flex c-flex--space-between">
+									<p><?php the_author_meta('last_name',$user_id); ?> <?php the_author_meta('first_name',$user_id); ?></p>
+									<?php /* SNS */
+									$group = SCF::get_user_meta($user_id,'sns');
+									if(SCF::get_user_meta($user_id,'sns_type') !=""){
+										echo '<div class="p-sns c-flex">' ;
+									} ?>
+									<?php foreach ((array)$group as $fields ) {
+												if($fields['sns_type'] != "" && $fields['sns_url'] != ""){
+													$my_sns = $fields['sns_type'];
+													if($my_sns == 'Instagram'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--insta" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-instagram"></i>
+														<span class="c-title__profile">Instagram</span>
+													</a>
+												<?php }
+												elseif($my_sns == 'Facebook'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--facebook" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-facebook-f"></i>
+														<span class="c-title__profile">Facebook</span>
+													</a>
+												<?php }
+												elseif($my_sns == 'YouTube'){ ?>
+													<a href="<?php echo esc_attr($fields['sns_url']) ?>" class="p-sns__button c-sns--youtube" target="_blank" rel="noopener noreferrer">
+														<i class="fab fa-youtube"></i>
+														<span class="c-title__profile">YouTube</span>
+													</a>
+											<?php }
+										}
 									}
-								} ?>
-							</dt>
-						<!-- 経歴 -->
-						<?php if(SCF::get_user_meta($user_id,'career') != ""){
-							$group = SCF::get_user_meta($user_id,'career');
-							$last_year = 0;
-							foreach ((array)$group as $fields ) { ?>
-								<dd class="c-definition__detail">
-									<?php if($last_year != $fields['career_year'] && $fields['career_year'] !=""){ ?>
-										<p class="c-definition__detail__item"><?php echo $fields['career_year']; ?></p>
-									<?php } ?>
-									<p class="c-definition__detail__item"><?php echo $fields['career_detail']; ?></p>
-								</dd>
-								<?php $last_year = $fields['career_year'];
-							}
-						} ?>
-						</dl>
-				<?php } ?>
+									if(SCF::get_user_meta($user_id,'sns_type') !=""){
+										echo '</div>' ;
+									} ?>
+								</dt>
+							<!-- 経歴 -->
+							<?php if(SCF::get_user_meta($user_id,'career') != ""){
+								$group = SCF::get_user_meta($user_id,'career');
+								$last_year = 0;
+								foreach ((array)$group as $fields ) { ?>
+									<dd class="c-definition__detail">
+										<?php if($last_year != $fields['career_year'] && $fields['career_year'] !=""){ ?>
+											<p class="c-definition__detail__item"><?php echo $fields['career_year']; ?></p>
+										<?php } ?>
+										<p class="c-definition__detail__item"><?php echo $fields['career_detail']; ?></p>
+									</dd>
+									<?php $last_year = $fields['career_year'];
+								}
+							} ?>
+							</dl>
+					<?php } ?>
 
-				<?php /* 受賞 */
-				$group       = SCF::get_user_meta($user_id,'award');
-				$have_ul_tag = false;
-				foreach ((array)$group as $fields ) {
-					if($fields['award_detail'] != ""){
-						if(!$have_ul_tag){ ?>
-							<ul class="c-bullet">
-							<?php $have_ul_tag = true;
-						} ?>
-						<li class="c-bullet__item"><?php echo $fields['award_detail']; ?></li>
+					<?php /* 受賞 */
+					$group       = SCF::get_user_meta($user_id,'award');
+					$have_ul_tag = false;
+					foreach ((array)$group as $fields ) {
+						if($fields['award_detail'] != ""){
+							if(!$have_ul_tag){ ?>
+								<ul class="c-bullet">
+								<?php $have_ul_tag = true;
+							} ?>
+							<li class="c-bullet__item"><?php echo $fields['award_detail']; ?></li>
+						<?php }
+					}
+					if($have_ul_tag){ ?>
+						</ul>
+						</div>
 					<?php }
-				}
-				if($have_ul_tag){ ?>
-					</ul>
-					</div>
-				<?php }
-				//写真がある場合のみ閉じタグを出力する
-				if(SCF::get_user_meta($user_id,'user_photo') != ""){
-					echo '</article>';
-				}
-			} ?><!-- 職人データforeach -end- -->
+					//写真がある場合のみ閉じタグを出力する
+					if(SCF::get_user_meta($user_id,'user_photo') != ""){
+						echo '</article>';
+					}
+				} ?><!-- 職人データforeach -end- -->
+			</article>
 		</article>
 		<!-- うるしときの職人表示ここまで -->
 		<article class="c-wrapper">
 			<?php get_template_part('/includes/archive-shop');?>
 		</article>
 	</main>
+	<div class="c-background-icon__left--cloisonne">
+	</div>
 	<?php get_footer(); ?>

--- a/wp-content/themes/urushitoki/production/php/page-sns.php
+++ b/wp-content/themes/urushitoki/production/php/page-sns.php
@@ -3,7 +3,9 @@
 	<?php get_template_part('/includes/header')?>
 
 		<div class="c-wrapper">
-
+		<?php $users = get_users(array('orderby'=>'ID','order'=>'ASC'));
+		foreach($users as $user) {
+			$user_id = $user->ID;?>
 		<?php /* SNS */
 			$group = SCF::get_user_meta($user_id,'sns');
 			foreach ((array)$group as $fields ) {

--- a/wp-content/themes/urushitoki/production/sass/object/component/_definition.scss
+++ b/wp-content/themes/urushitoki/production/sass/object/component/_definition.scss
@@ -6,7 +6,7 @@
 .c-definition{
 	width: 100%;
 	color:variable.$font-color--definiton;
-
+	margin-bottom: 30px;
 	&__title{
 		font-size: variable.$font-size--definiton-term;
 		padding-bottom: 30px;

--- a/wp-content/themes/urushitoki/src/sass/object/component/_definition.scss
+++ b/wp-content/themes/urushitoki/src/sass/object/component/_definition.scss
@@ -6,7 +6,7 @@
 .c-definition{
 	width: 100%;
 	color:variable.$font-color--definiton;
-
+	margin-bottom: 30px;
 	&__title{
 		font-size: variable.$font-size--definiton-term;
 		padding-bottom: 30px;


### PR DESCRIPTION
- `l-main--about` を追加しコンテンツとの間に余白を持たせる
 デザインカンプが478px離れていたためそれに従っております
 
その他、デザインカンプに合わせて以下の変更を加えております

- `<div class="p-sns c-flex">`がボタンごとに出力されるのをボタン全体を囲うように変更
- Facebookボタンを表示
- 経歴と受賞の間に余白を追加
 他のページで登場していなそうだったので`c-definition`に余白を付けました
- ページの一番下に文様を追加

よろしくお願いいたします。