### PR TITLE
media-textモバイル時余白追加

### DIFF
--- a/wp-content/themes/urushitoki/css/editor-style.css
+++ b/wp-content/themes/urushitoki/css/editor-style.css
@@ -2623,7 +2623,7 @@ utility
 }
 @media (max-width: 1024px) {
   .wp-block-columns.is-style-p-media-column .wp-block-column:nth-child(2n) {
-    margin-left: 0pxz;
+    margin-left: 0px;
   }
 }
 .wp-block-columns.is-style-p-media-column .wp-block-image {
@@ -2637,6 +2637,16 @@ utility
   -o-object-position: top;
      object-position: top;
   height: auto;
+}
+
+.wp-block-media-text__content {
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 599px) {
+  .wp-block-media-text__content {
+    margin-top: 20px;
+  }
 }
 
 .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media img {

--- a/wp-content/themes/urushitoki/css/urushidoki-block-style.css
+++ b/wp-content/themes/urushitoki/css/urushidoki-block-style.css
@@ -2623,7 +2623,7 @@ utility
 }
 @media (max-width: 1024px) {
   .wp-block-columns.is-style-p-media-column .wp-block-column:nth-child(2n) {
-    margin-left: 0pxz;
+    margin-left: 0px;
   }
 }
 .wp-block-columns.is-style-p-media-column .wp-block-image {
@@ -2637,6 +2637,16 @@ utility
   -o-object-position: top;
      object-position: top;
   height: auto;
+}
+
+.wp-block-media-text__content {
+  /* tablet */
+  /* SmartPhone */
+}
+@media (max-width: 599px) {
+  .wp-block-media-text__content {
+    margin-top: 20px;
+  }
 }
 
 .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media img {

--- a/wp-content/themes/urushitoki/production/sass/urushidoki-block-style.scss
+++ b/wp-content/themes/urushitoki/production/sass/urushidoki-block-style.scss
@@ -124,7 +124,7 @@
 	}
 	.wp-block-column:nth-child(2n){
 		@include mixin.breakpoint( breakpoint-tab ){
-			margin-left: 0pxz;
+			margin-left: 0px;
 		}
 	}
 	.wp-block-image{
@@ -138,6 +138,14 @@
 		}
 	}
 }
+
+// media-text モバイル時 上部余白
+.wp-block-media-text__content{
+	@include mixin.breakpoint( breakpoint-sp ){
+		margin-top: 20px;
+	}
+}
+
 // モバイル時の画像調整
 .wp-block-media-text.is-stacked-on-mobile .wp-block-media-text__media {
 	img{


### PR DESCRIPTION
media-textモバイル時に画像とテキスト間に余白を追加しました。（使用箇所：うるしと楽器）