### PR TITLE
動画・静止画切り替えポイントを1024pxに変更

### DIFF
--- a/wp-content/themes/urushitoki/js/header-video.js
+++ b/wp-content/themes/urushitoki/js/header-video.js
@@ -1,8 +1,8 @@
 jQuery(window).on('load resize', function(){
 	let windowWidth = window.innerWidth;
-	let windowSp    = 599;
+	let windowTab    = 1024;
 	const video     = document.getElementById('header-video');
-	if (windowWidth <= windowSp) {
+	if (windowWidth <= windowTab) {
 		video.pause()
 		video.addEventListener('pause', function() {
 			video.load();

--- a/wp-content/themes/urushitoki/production/js/header-video.js
+++ b/wp-content/themes/urushitoki/production/js/header-video.js
@@ -1,8 +1,8 @@
 jQuery(window).on('load resize', function(){
 	let windowWidth = window.innerWidth;
-	let windowSp    = 599;
+	let windowTab    = 1024;
 	const video     = document.getElementById('header-video');
-	if (windowWidth <= windowSp) {
+	if (windowWidth <= windowTab) {
 		video.pause()
 		video.addEventListener('pause', function() {
 			video.load();


### PR DESCRIPTION
調べてみたところ、動画の容量が大きすぎるため、TabやSpで再生できないようです。
一旦、動画と静止画の切り替えを599pxから1024pxに変更し、Tabでも静止画再生するようにしております。