### PR TITLE
特商法ページ、フッター追加

### DIFF
--- a/wp-content/themes/urushitoki/css/editor-style.css
+++ b/wp-content/themes/urushitoki/css/editor-style.css
@@ -81,7 +81,7 @@ a {
 }
 
 .l-main--about {
-  margin-top: 200px;
+  margin-top: 180px;
 }
 
 .l-main--information {

--- a/wp-content/themes/urushitoki/css/style.css
+++ b/wp-content/themes/urushitoki/css/style.css
@@ -81,7 +81,7 @@ a {
 }
 
 .l-main--about {
-  margin-top: 200px;
+  margin-top: 180px;
 }
 
 .l-main--information {

--- a/wp-content/themes/urushitoki/css/urushidoki-block-style.css
+++ b/wp-content/themes/urushitoki/css/urushidoki-block-style.css
@@ -81,7 +81,7 @@ a {
 }
 
 .l-main--about {
-  margin-top: 200px;
+  margin-top: 180px;
 }
 
 .l-main--information {

--- a/wp-content/themes/urushitoki/footer.php
+++ b/wp-content/themes/urushitoki/footer.php
@@ -11,6 +11,7 @@
 				<ul class="p-footer__contact">
 					<li class="p-footer__contact__list"><a href="<?php echo home_url('/contact/');  ?>" class="c-text--white">お問い合わせ・ご依頼</a></li>
 					<li class="p-footer__contact__list"><a href="<?php echo home_url('/faq/');  ?>" class="c-text--white">よくある質問</a></li>
+					<li class="p-footer__contact__list"><a href="<?php echo home_url('/tokushoho/');  ?>" class="c-text--white">特定商取引法</a></li>
 					<li class="p-footer__contact__list"><address class="c-text--white">076-229-0860</address></li>
 				</ul>
 			</nav>

--- a/wp-content/themes/urushitoki/production/php/footer.php
+++ b/wp-content/themes/urushitoki/production/php/footer.php
@@ -11,6 +11,7 @@
 				<ul class="p-footer__contact">
 					<li class="p-footer__contact__list"><a href="<?php echo home_url('/contact/');  ?>" class="c-text--white">お問い合わせ・ご依頼</a></li>
 					<li class="p-footer__contact__list"><a href="<?php echo home_url('/faq/');  ?>" class="c-text--white">よくある質問</a></li>
+					<li class="p-footer__contact__list"><a href="<?php echo home_url('/tokushoho/');  ?>" class="c-text--white">特定商取引法</a></li>
 					<li class="p-footer__contact__list"><address class="c-text--white">076-229-0860</address></li>
 				</ul>
 			</nav>


### PR DESCRIPTION
特商法のページへのリンクをフッターに追加いたしました。
特商法のパーマネントは日本語になっていたので「tokushoho」に変更しております。